### PR TITLE
Bug fix : prevent the paddle to move to the mouse position after the game is resumed.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4516,6 +4516,10 @@ int main (int argc, char *argv[]) {
     control.get(); //Check for keypresses and joystick events
     while (SDL_PollEvent(&sdlevent) )
     {
+      int mouseRelPosX;
+      int mouseRelPosY;
+      //must be read on each event to avoid the paddle to move to the mouse position after the game is resumed
+      SDL_GetRelativeMouseState(&mouseRelPosX, &mouseRelPosY);
       if( sdlevent.type == SDL_KEYDOWN ) {
 
         if(var.showHighScores)
@@ -4588,8 +4592,10 @@ int main (int argc, char *argv[]) {
           if(!var.titleScreenShow)
           {
             var.titleScreenShow=1;
+            pauseGame();
           } else {
             var.titleScreenShow=0;
+            resumeGame();
           }
         }
 #ifndef WIN32
@@ -4629,7 +4635,7 @@ int main (int argc, char *argv[]) {
           else
            var.menuItem = 0;
         } else {
-          control.movePaddle(mousex);
+          control.movePaddle(paddle.posx + (mouseRelPosX * var.glunits_per_xpixel));
         }
       } else if( sdlevent.type == SDL_MOUSEBUTTONDOWN )
       {

--- a/main.cpp
+++ b/main.cpp
@@ -4516,10 +4516,6 @@ int main (int argc, char *argv[]) {
     control.get(); //Check for keypresses and joystick events
     while (SDL_PollEvent(&sdlevent) )
     {
-      int mouseRelPosX;
-      int mouseRelPosY;
-      //must be read on each event to avoid the paddle to move to the mouse position after the game is resumed
-      SDL_GetRelativeMouseState(&mouseRelPosX, &mouseRelPosY);
       if( sdlevent.type == SDL_KEYDOWN ) {
 
         if(var.showHighScores)
@@ -4635,7 +4631,7 @@ int main (int argc, char *argv[]) {
           else
            var.menuItem = 0;
         } else {
-          control.movePaddle(paddle.posx + (mouseRelPosX * var.glunits_per_xpixel));
+          control.movePaddle(paddle.posx + (sdlevent.motion.xrel * var.glunits_per_xpixel));
         }
       } else if( sdlevent.type == SDL_MOUSEBUTTONDOWN )
       {


### PR DESCRIPTION
Steps to reproduce :

- start a new game,
- hit the escape key to display menu before the ball hit the paddle,
- move your mouse on the edge of the screen,
- hit the escape key to close menu,
- move slightly your mouse.

Actual results :
The paddle move on the edge of the screen and miss the ball.

Expected result :
The paddle should not move on the edge of the screen after the menu is exited and the mouse slightly moved.

This behavior is also observed when the F1 key is pressed instead of the escape key.