### PR TITLE
Fixed Linux installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 PREFIX?=/usr/local
 
-DESTDIR?=$(PREFIX)share/games/sdl-ball/
-
-DATADIR?=themes/
-BINDIR=bin/
+DATADIR?=$(PREFIX)/share/games/sdl-ball/themes/
+BINDIR?=$(PREFIX)/bin/
 
 #append -DWITH_WIIUSE to compile with WIIUSE support!
 #append -DNOSOUND to compile WITHOUT sound support
@@ -36,9 +34,8 @@ clean:
 install: $(EXECUTABLE) install-bin install-data
 
 install-bin:
-	mkdir -p $(DESTDIR)
-	cp $(EXECUTABLE) $(DESTDIR)
-	ln -s $(DESTDIR)$(EXECUTABLE) $(PREFIX)$(BINDIR)
+	mkdir -p $(DESTDIR)$(BINDIR)
+	cp $(EXECUTABLE) $(DESTDIR)$(BINDIR)
 
 install-data:
 	mkdir -p $(DESTDIR)$(DATADIR)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-ifndef PREFIX
-	PREFIX=/usr/local/
-endif
+PREFIX?=/usr/local
 
 DESTDIR?=$(PREFIX)share/games/sdl-ball/
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ BINDIR?=$(PREFIX)/bin/
 
 #append -DWITH_WIIUSE to compile with WIIUSE support!
 #append -DNOSOUND to compile WITHOUT sound support
-STRIP=strip
 CXX?=g++
 
 CXXFLAGS+=-Wall `sdl-config --cflags` -DDATADIR="\"$(DATADIR)\""
@@ -23,7 +22,6 @@ all: $(SOURCES) $(EXECUTABLE)
 	
 $(EXECUTABLE): $(OBJECTS)
 	$(CXX) $(LDFLAGS) $(OBJECTS) $(LIBS) -o $@
-	$(STRIP) $@
 
 .cpp.o:
 	$(CXX) -c $(CXXFLAGS) $< -o $@


### PR DESCRIPTION
Currently, https://build.opensuse.org/package/show/games/sdl-ball is working this around with a manual installation as the current one is quite borked as `DESTDIR` and `DATADIR` are confused and `PREFIX` can't be properly set and it isn't adhered always.