### PR TITLE
Fixed the speed ui not updating after ball powerups that reset it.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2145,6 +2145,8 @@ class ballManager {
           }
         }
       }
+
+      getSpeed();
     }
 };
 


### PR DESCRIPTION
Without this fix, when picking up ball power ups that reset its speed
(big ball and regular ball), the green bar on the right that shows the
current speed doesn't update until the next collision, meaning a wrong
speed value is shown until the next collision happens.

This just calls the getSpeed method after applying a ball powerup in the ball manager.